### PR TITLE
Dev

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,6 +161,8 @@ docker-build-and-push:
   before_script:
     - echo "======================== SETUP BUILDX ENVIRONMENT =========================="
     - docker info
+    - sed -i 's#https\?://dl-cdn.alpinelinux.org/alpine#https://mirrors.cernet.edu.cn/alpine#g' /etc/apk/repositories
+    - apk update
     - apk add --no-cache git
     # 创建并使用 buildx builder
     - docker buildx create --use --name multiarch-builder --driver docker-container --platform linux/amd64,linux/arm64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/ppc64le,linux/riscv64,linux/s390x,linux/mips64le --bootstrap || docker buildx use multiarch-builder

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,7 +152,7 @@ maven-build:main:
 #    - dev
 
 docker-build-and-push:
-  image: registry.gdut.edu.cn/docker/library/docker:stable
+  image: registry.gdut.edu.cn/docker/library/docker:24-cli
   stage: image-build
   tags:
     - Docker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,6 +190,9 @@ docker-build-and-push:
     # - docker rmi ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME)
     - echo "============================ EXPORT IMAGE TAGS ============================="
     - echo "COMMIT_TIME=$COMMIT_TIME" >> build.env
+  after_script:
+    - echo "============================ CLEAN BUILD CACHE ============================="
+    - docker buildx prune -a -f
   artifacts:
     reports:
       dotenv: build.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,13 +157,13 @@ docker-build-and-push:
   tags:
     - Docker
   services:
-    - name: docker:stable
+    - name: registry.gdut.edu.cn/docker/library/docker:24-cli
   before_script:
     - echo "======================== SETUP BUILDX ENVIRONMENT =========================="
     - docker info
     - apk add --no-cache git
     # 创建并使用 buildx builder
-    - docker buildx create --use --name multiarch-builder --driver docker-container --platform linux/amd64,linux/arm64,linux/arm/v7 --bootstrap || docker buildx use multiarch-builder
+    - docker buildx create --use --name multiarch-builder --driver docker-container --platform linux/amd64,linux/arm64,linux/arm/v5,linux/arm/v6,linux/arm/v7,linux/ppc64le,linux/riscv64,linux/s390x,linux/mips64le --bootstrap || docker buildx use multiarch-builder
     - docker buildx inspect --bootstrap
   script:
     - echo "================================= LOAD ENV ================================="
@@ -181,7 +181,7 @@ docker-build-and-push:
     - echo "======================= BUILD AND PUSH DOCKER IMAGES ======================="
     - |
       docker buildx build \
-      --platform linux/amd64,linux/arm64 \
+      --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
       --tag ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME) \
       --tag ${HARBORHOST}/gdutdays/gdutdays:latest \
       --push \
@@ -306,8 +306,8 @@ image-sign:
       deb http://mirrors.gdut.edu.cn/ubuntu/ jammy-security main restricted universe multiverse
       deb-src http://mirrors.gdut.edu.cn/ubuntu/ jammy-security main restricted universe multiverse' > /etc/apt/sources.list
     - apt update -y
-    - echo "=============================== INSTALL CURL ==============================="
-    - apt install curl -y
+    - echo "======================== INSTALL REQUIRED TOOLS ============================"
+    - apt install curl jq skopeo -y
   script:
     - echo "================================= LOAD ENV ================================="
     - env
@@ -322,8 +322,38 @@ image-sign:
     - cosign generate-key-pair
     - echo "============================= LOGIN TO HARBOR =============================="
     - cosign login -u ${USERNAME} -p ${PASSWORD} ${HARBORHOST}
-    - echo "=============================== IMAGE SIGN ================================="
+    - echo "==================== EXTRACT ARCHITECTURE DIGESTS ========================="
+    # 使用 skopeo 获取镜像 manifest 信息
+    - |
+      echo "Fetching manifest for ${HARBORHOST}/gdutdays/gdutdays:latest"
+      skopeo inspect --raw docker://${HARBORHOST}/gdutdays/gdutdays:latest > manifest.json
+      
+      # 解析 manifest，提取每个架构的 digest
+      cat manifest.json | jq -r '
+        if .manifests then
+          .manifests[] | "\(.platform.architecture):\(.digest)"
+        else
+          "single-arch:\(.config.digest // "unknown")"
+        end
+      ' > arch_digests.txt
+      
+      echo "Architecture digests:"
+      cat arch_digests.txt
+    - echo "===================== SIGN EACH ARCHITECTURE IMAGE ========================"
+    # 签名 manifest list (整体镜像)
+    - echo "Signing manifest list for latest tag..."
     - cosign sign --key cosign.key ${HARBORHOST}/gdutdays/gdutdays:latest
+    # 签名每个架构的镜像
+    - |
+      echo "Signing individual architecture images..."
+      while IFS=: read -r arch digest; do
+        if [ "$arch" != "single-arch" ] && [ -n "$digest" ]; then
+          echo "Signing $arch architecture with digest: $digest"
+          cosign sign --key cosign.key ${HARBORHOST}/gdutdays/gdutdays@${digest}
+        else
+          echo "Skipping single-arch or empty digest"
+        fi
+      done < arch_digests.txt
     - echo "================================ CHART SIGN ================================"
     - cosign sign --key cosign.key $HARBORHOST/gdutdays/gdutdays-helm:${BIG_VERSION}-$(echo $COMMIT_TIME)
     - echo "========================== FIX FILE PERMISSIONS ============================"
@@ -336,6 +366,10 @@ image-sign:
     paths:
       - cosign.key
       - cosign.pub
+      - arch_digests.txt
+      - arch_digests_versioned.txt
+      - manifest.json
+      - manifest_versioned.json
     reports:
       dotenv: build.env
     expire_in: 30 min

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,21 +158,36 @@ docker-build-and-push:
     - Docker
   services:
     - name: docker:stable
+  before_script:
+    - echo "======================== SETUP BUILDX ENVIRONMENT =========================="
+    - docker info
+    - apk add --no-cache git
+    # 创建并使用 buildx builder
+    - docker buildx create --use --name multiarch-builder --driver docker-container --platform linux/amd64,linux/arm64,linux/arm/v7 --bootstrap || docker buildx use multiarch-builder
+    - docker buildx inspect --bootstrap
   script:
     - echo "================================= LOAD ENV ================================="
     - env
     - echo "COMMIT_TIME=${COMMIT_TIME}"
     - echo "============================= LOGIN TO HARBOR =============================="
     - docker login -u ${USERNAME} -p ${PASSWORD} ${HARBORHOST}
-    - echo "=========================== BUILD DOCKER IMAGES ============================"
-    - docker build -t ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME) .
-    - echo "========================== TAG IMAGES WITH LATEST =========================="
-    - docker tag ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME) ${HARBORHOST}/gdutdays/gdutdays:latest
-    - echo "========================== PUSH IMAGES TO HARBOR ==========================="
-    - docker push ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME)
-    - docker push ${HARBORHOST}/gdutdays/gdutdays:latest
-    - echo "============================= CLEAN UP MIRRORS ============================="
-    - docker rmi ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME)
+    # - echo "=========================== BUILD DOCKER IMAGES ============================"
+    # - docker build -t ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME) .
+    # - echo "========================== TAG IMAGES WITH LATEST =========================="
+    # - docker tag ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME) ${HARBORHOST}/gdutdays/gdutdays:latest
+    # - echo "========================== PUSH IMAGES TO HARBOR ==========================="
+    # - docker push ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME)
+    # - docker push ${HARBORHOST}/gdutdays/gdutdays:latest
+    - echo "======================= BUILD AND PUSH DOCKER IMAGES ======================="
+      - |
+      docker buildx build \
+      --platform linux/amd64,linux/arm64 \
+      --tag ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME) \
+      --tag ${HARBORHOST}/gdutdays/gdutdays:latest \
+      --push \
+      .
+    # - echo "============================= CLEAN UP MIRRORS ============================="
+    # - docker rmi ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME)
     - echo "============================ EXPORT IMAGE TAGS ============================="
     - echo "COMMIT_TIME=$COMMIT_TIME" >> build.env
   artifacts:
@@ -311,6 +326,9 @@ image-sign:
     - cosign sign --key cosign.key ${HARBORHOST}/gdutdays/gdutdays:latest
     - echo "================================ CHART SIGN ================================"
     - cosign sign --key cosign.key $HARBORHOST/gdutdays/gdutdays-helm:${BIG_VERSION}-$(echo $COMMIT_TIME)
+    - echo "========================== FIX FILE PERMISSIONS ============================"
+    - chmod 644 cosign.key cosign.pub
+    - ls -la cosign.*
     - echo "================================ EXPORT KEY ================================"
     - echo "The Password of the key is Harbor account's password, the key will reserved for 30 minutes."
     - echo "COMMIT_TIME=${COMMIT_TIME}" >> build.env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ sonarqube-check:
     - maven
   before_script:
     - echo "=========================== CHANGE MAVEN MIRROR ============================"
+    - mkdir -p $HOME/.m2 || true
     - echo '<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
@@ -31,10 +32,10 @@ sonarqube-check:
                 <id>nexus-aliyun</id>
                 <mirrorOf>*</mirrorOf>
                 <name>Nexus aliyun</name>
-                <url>http://maven.aliyun.com/nexus/content/groups/public/</url>
+                <url>https://mirrors.gdut.edu.cn/nexus/repository/maven-public/</url>
               </mirror>
             </mirrors>
-            </settings>' > $HOME/.m2/settings.xml
+            </settings>' > $HOME/.m2/settings.xml || true
   variables:
     SONAR_USER_HOME: "${CI_PROJECT_DIR}/.sonar"  # Defines the location of the analysis task cache
     GIT_DEPTH: "0"  # Tells git to fetch all the branches of the project, required by the analysis task
@@ -55,6 +56,7 @@ maven-build:dev:
     - maven
   before_script:
     - echo "=========================== CHANGE MAVEN MIRROR ============================"
+    - mkdir -p $HOME/.m2 || true
     - echo '<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
@@ -64,10 +66,10 @@ maven-build:dev:
                 <id>nexus-aliyun</id>
                 <mirrorOf>*</mirrorOf>
                 <name>Nexus aliyun</name>
-                <url>http://maven.aliyun.com/nexus/content/groups/public/</url>
+                <url>https://mirrors.gdut.edu.cn/nexus/repository/maven-public/</url>
               </mirror>
             </mirrors>
-            </settings>' > $HOME/.m2/settings.xml
+            </settings>' > $HOME/.m2/settings.xml || true
   script:
     - echo "========================== GENERATE VERSION TAGS ==========================="
     - export COMMIT_TIME=$(echo $CI_JOB_STARTED_AT | sed -E 's/^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})\+.*$/\1\2\3\4\5\6/g')
@@ -93,6 +95,7 @@ maven-build:main:
     - maven
   before_script:
     - echo "=========================== CHANGE MAVEN MIRROR ============================"
+    - mkdir -p $HOME/.m2 || true
     - echo '<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
@@ -102,10 +105,10 @@ maven-build:main:
                 <id>nexus-aliyun</id>
                 <mirrorOf>*</mirrorOf>
                 <name>Nexus aliyun</name>
-                <url>http://maven.aliyun.com/nexus/content/groups/public/</url>
+                <url>https://mirrors.gdut.edu.cn/nexus/repository/maven-public/</url>
               </mirror>
             </mirrors>
-            </settings>' > $HOME/.m2/settings.xml
+            </settings>' > $HOME/.m2/settings.xml || true
   script:
     - echo "========================== GENERATE VERSION TAGS ==========================="
     - export COMMIT_TIME=$(echo $CI_JOB_STARTED_AT | sed -E 's/^([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})\+.*$/\1\2\3\4\5\6/g')

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -179,7 +179,7 @@ docker-build-and-push:
     # - docker push ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME)
     # - docker push ${HARBORHOST}/gdutdays/gdutdays:latest
     - echo "======================= BUILD AND PUSH DOCKER IMAGES ======================="
-      - |
+    - |
       docker buildx build \
       --platform linux/amd64,linux/arm64 \
       --tag ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gdut.edu.cn/docker/library/openjdk:17-oracle
+FROM registry.gdut.edu.cn/docker/library/eclipse-temurin:17-jre
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
-FROM registry.gdut.edu.cn/docker/library/eclipse-temurin:17-jre
+# Deprecated: 以上使用的是 HotSpot 运行时，已弃用
+#FROM registry.gdut.edu.cn/docker/library/eclipse-temurin:17-jre
+#ARG JAR_FILE=target/*.jar
+#COPY ${JAR_FILE} app.jar
+#RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
+#ENTRYPOINT ["java","-jar","/app.jar","--spring.profiles.active=prod","-XX:+UseZGC","-XX:ZCollectionInterval=120", "-XX:ZAllocationSpikeTolerance=4","-XX:-ZProactive",  "-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=./errorDump.hprof"]
+
+# 使用新的 OpenJ9 运行时
+FROM docker.m.ixdev.cn/library/ibm-semeru-runtimes:open-17.0.17_9-jre-noble
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
+
+# 设置时区
 RUN ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
-ENTRYPOINT ["java","-jar","/app.jar","--spring.profiles.active=prod","-XX:+UseZGC","-XX:ZCollectionInterval=120", "-XX:ZAllocationSpikeTolerance=4","-XX:-ZProactive",  "-XX:+HeapDumpOnOutOfMemoryError","-XX:HeapDumpPath=./errorDump.hprof"]
+
+# 仅支持 OpenJ9 的 JVM 参数（JVM 参数必须在 -jar 之前）
+ENTRYPOINT ["java", "-Xgcpolicy:gencon", "-Xquickstart", "-Xdump:heap:events=throw,filter=java/lang/OutOfMemoryError,file=/tmp/errorDump.hprof", "-jar", "/app.jar", "--spring.profiles.active=prod"]


### PR DESCRIPTION
This pull request updates the CI/CD pipeline and Docker image to improve reliability, performance, and multi-architecture support. The main changes include switching the base JVM image to OpenJ9, updating Maven mirror settings, enhancing Docker build and push steps for multi-architecture images, and improving the image signing process.

**Docker Image Updates:**
- Switched the base image in `Dockerfile` from HotSpot-based OpenJDK to IBM Semeru OpenJ9 for better performance and resource efficiency. Updated JVM parameters to use OpenJ9-specific options.

**CI Pipeline Improvements:**

*__Maven Configuration:__*
- Changed Maven mirror URLs to use a more reliable mirror (`mirrors.gdut.edu.cn`) and ensured the `.m2` directory is created before writing settings, with error handling. These changes were applied to all Maven-related jobs in `.gitlab-ci.yml`. [[1]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R25) [[2]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7L34-R38) [[3]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R59) [[4]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7L67-R72) [[5]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R98) [[6]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7L105-R111)

*__Docker Build and Push:__*
- Updated the Docker build job to use the latest Docker CLI image and set up Docker Buildx for multi-architecture builds (amd64, arm64, etc.). The build and push process now uses `docker buildx build --push` to create and push multi-arch images. Added cache cleanup after the build.

*__Image Signing:__*
- Enhanced the image signing job to install additional tools (`jq`, `skopeo`) for extracting and signing digests of all image architectures. Now, each architecture-specific image and the manifest list are signed individually for improved security and compliance. [[1]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7L291-R315) [[2]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7L307-R377)