### PR TITLE
Dev

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ sonarqube-check:
     policy: pull-push
   script:
     - mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -DskipTests -Dmaven.repo.local=cache
-    - chmod -R 644 .sonar/cache
+    - chmod -R 777 .sonar/cache
   allow_failure: true
   only:
     - dev

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,7 @@ sonarqube-check:
     paths:
       - cache/
       - sonar-scanner/
+    policy: pull-push
   script:
     - mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -DskipTests -Dmaven.repo.local=cache
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,8 @@ sonarqube-check:
   cache:
     key: "${CI_JOB_NAME}"
     paths:
-      - .sonar/cache
+      - cache/
+      - sonar-scanner/
   script:
     - mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -DskipTests -Dmaven.repo.local=cache
   allow_failure: true
@@ -54,6 +55,11 @@ maven-build:dev:
   stage: maven-build
   tags:
     - maven
+  cache:
+    key: "${CI_JOB_NAME}"
+    paths:
+      - cache/
+    policy: pull-push
   before_script:
     - echo "=========================== CHANGE MAVEN MIRROR ============================"
     - mkdir -p $HOME/.m2 || true
@@ -93,6 +99,11 @@ maven-build:main:
   stage: maven-build
   tags:
     - maven
+  cache:
+    key: "${CI_JOB_NAME}"
+    paths:
+      - cache/
+    policy: pull-push
   before_script:
     - echo "=========================== CHANGE MAVEN MIRROR ============================"
     - mkdir -p $HOME/.m2 || true
@@ -118,7 +129,14 @@ maven-build:main:
     - echo "=========================== EXPORT VERSION TAGS ============================"
     - echo "COMMIT_TIME=$COMMIT_TIME" >> build.env
     - echo "========================== PUBLISH MAVEN PACKAGE ==========================="
-    - curl --header "PRIVATE-TOKEN:${PACKAGE_PUBLISH_TOKEN}" --upload-file target/*.jar "https://git.gdutnic.com/api/v4/projects/${CI_PROJECT_ID}/packages/generic/gdutdays/${BIG_VERSION}-${COMMIT_TIME}/gdutdays.jar"
+    - export PACKAGE_NAME=gdutdays.jar
+    - export PACKAGE_URL="${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/gdutdays/${BIG_VERSION}-${COMMIT_TIME}/${PACKAGE_NAME}"
+    - echo "Uploading to ${PACKAGE_URL}"
+    - curl --header "PRIVATE-TOKEN:${CI_JOB_TOKEN}" --upload-file server/target/*.jar "${PACKAGE_URL}"
+    # - curl --header "PRIVATE-TOKEN:${PACKAGE_PUBLISH_TOKEN}" --upload-file target/*.jar "https://git.gdutnic.com/api/v4/projects/${CI_PROJECT_ID}/packages/generic/gdutdays/${BIG_VERSION}-${COMMIT_TIME}/gdutdays.jar"
+    - echo "=========================== EXPORT VERSION TAGS ============================"
+    - echo "PACKAGE_NAME=${PACKAGE_NAME}" >> build.env
+    - echo "PACKAGE_URL=${PACKAGE_URL}" >> build.env
   artifacts:
     reports:
       dotenv: build.env
@@ -186,6 +204,8 @@ docker-build-and-push:
       --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x \
       --tag ${HARBORHOST}/gdutdays/gdutdays:${BIG_VERSION}-$(echo $COMMIT_TIME) \
       --tag ${HARBORHOST}/gdutdays/gdutdays:latest \
+      --cache-to type=s3,region=${MINIO_REIGON},bucket=${MINIO_BUCKET},name=docker-build-cache,endpoint_url=${MINIO_ENDPOINT_URL},use_path_style=true,access_key_id=${MINIO_ACCESS_KEY},secret_access_key=${MINIO_SECRET_KEY},mode=max \
+      --cache-from type=s3,region=${MINIO_REIGON},bucket=${MINIO_BUCKET},name=docker-build-cache,endpoint_url=${MINIO_ENDPOINT_URL},use_path_style=true,access_key_id=${MINIO_ACCESS_KEY},secret_access_key=${MINIO_SECRET_KEY} \
       --push \
       .
     # - echo "============================= CLEAN UP MIRRORS ============================="
@@ -267,11 +287,18 @@ release-new-version:
     - echo "================================= LOAD ENV ================================="
     - env
     - echo "COMMIT_TIME=${COMMIT_TIME}"
+    - echo "Creating release for ${BIG_VERSION}-${COMMIT_TIME}"
+    - echo "Linking asset ${PACKAGE_NAME} -> ${PACKAGE_URL}"
     #- echo "=================== PUBLISH JAR FILE TO Package Registry ==================="
     #- curl --header "PRIVATE-TOKEN:${PACKAGE_PUBLISH_TOKEN}" --upload-file target/*.jar "https://git.gdutnic.com/api/v4/projects/2/packages/generic/gdutday/${BIG_VERSION}-${COMMIT_TIME}/gdutdays.jar"
   release:
     tag_name: "${BIG_VERSION}-${COMMIT_TIME}"
     description: "This is a release of version ${BIG_VERSION}-${COMMIT_TIME}."
+    assets:
+      links:
+        - name: "${PACKAGE_NAME}"
+          url: "${PACKAGE_URL}"
+          link_type: "package"
   allow_failure: true
   only:
     - main

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,11 +43,9 @@ sonarqube-check:
     key: "${CI_JOB_NAME}"
     paths:
       - cache/
-      - .sonar/cache
     policy: pull-push
   script:
     - mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -DskipTests -Dmaven.repo.local=cache
-    - chmod -R 777 .sonar/cache
   allow_failure: true
   only:
     - dev

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,10 +43,11 @@ sonarqube-check:
     key: "${CI_JOB_NAME}"
     paths:
       - cache/
-      - sonar-scanner/
+      - .sonar/cache
     policy: pull-push
   script:
     - mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -DskipTests -Dmaven.repo.local=cache
+    - chmod -R 644 .sonar/cache
   allow_failure: true
   only:
     - dev


### PR DESCRIPTION
This pull request updates the `.gitlab-ci.yml` file to improve caching, artifact publishing, and release asset management in the CI/CD pipeline. The changes mainly focus on optimizing Maven and Docker build caching, enhancing the publishing of Maven artifacts, and improving the release process by including published artifacts as release assets.

**CI/CD Pipeline Improvements:**

* Switched Maven and SonarQube jobs to use a shared `cache/` directory with a `pull-push` policy to speed up builds and reduce redundant downloads. [[1]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7L45-R46) [[2]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R58-R62) [[3]](diffhunk://#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7R102-R106)
* Enhanced Docker build caching by configuring buildx to cache layers to and from an S3-compatible storage, improving build performance and efficiency.

**Artifact Publishing and Release Management:**

* Refactored the Maven artifact publishing step to:
  * Use the correct artifact path (`server/target/*.jar`).
  * Use the `${CI_JOB_TOKEN}` for authentication.
  * Export and log artifact name and URL for downstream jobs.
* Updated the release job to:
  * Output information about the release and linked asset.
  * Attach the published JAR as a release asset using dynamically set name and URL.